### PR TITLE
Upgrade to go v1.16

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: ["1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+        version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
   test:
     strategy:
         matrix:
-          version: ["1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+          version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
   race-condition:
     strategy:
       matrix:
-        version: ["1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+        version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 http-gallery-beego
 uploads/*
 thumbnails/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![cloud_build_status](https://storage.googleapis.com/gcp-build-badge/http-gallery-beego/statusbadge.svg)](https://github.com/lescactus/http-gallery-beego) [![Go build and test](https://github.com/lescactus/http-gallery-beego/actions/workflows/go.yaml/badge.svg)](https://github.com/lescactus/http-gallery-beego/actions/workflows/go.yaml)
 
-![go](https://img.shields.io/badge/go->=1.14-blue)
+![go](https://img.shields.io/badge/go->=1.16-blue)
 
 A Beego web app that allow users to upload local images that are displayed in a html gallery and carousel. This is the rewriting in Go of one of my previous mini web project: **[http_gallery](https://github.com/lescactus/http_gallery)**.
 
@@ -19,7 +19,7 @@ It uses:
 
 ## Requirements
 
-* Golang 1.14 or higher
+* Golang 1.16 or higher
 
 ## Getting started
 
@@ -69,7 +69,7 @@ Now point your browser at http://127.0.0.1/
 
 ### From source with Go
 
-You need a working [go](https://golang.org/doc/install) toolchain (It has been developped and tested with go 1.14 and should work with go >= 1.14). Refer to the official documentation for more information (or from your Linux/Mac/Windows distribution documentation to install it from your favorite package manager).
+You need a working [go](https://golang.org/doc/install) toolchain (It has been developped and tested with go 1.16 and should work with go >= 1.16). Refer to the official documentation for more information (or from your Linux/Mac/Windows distribution documentation to install it from your favorite package manager).
 
 ```bash
 # Clone this repository
@@ -90,7 +90,7 @@ If you don't have [go](https://golang.org/doc/install) installed but have docker
 ```bash
 # Build from sources inside a docker container. Use the '-o' flag to change the compiled binary name
 # Warning: the compiled binary belongs to root:root
-docker run --rm -it -v "$PWD":/app -w /app golang:1.14 go build
+docker run --rm -it -v "$PWD":/app -w /app golang:1.16 go build
 
 # Default compiled binary is http-gallery-beego
 # You can optionnaly move it somewhere in your $PATH to access it shell wide

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -52,13 +52,12 @@ func isContentTypeAllowed(contentType string) bool {
 }
 
 // Return true if file is a real image and false if not
-func isAnImage(f fs.DirEntry) bool {
-	if !f.IsDir() {
-		f, err := os.Open(f.Name())
+func isAnImage(d fs.DirEntry) bool {
+	if !d.IsDir() {
+		f, err := os.Open(d.Name())
 		if err != nil {
 			return false
 		}
-
 		contentType, err := getFileContentType(f)
 		if err != nil {
 			return false

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -54,7 +54,7 @@ func isContentTypeAllowed(contentType string) bool {
 // Return true if file is a real image and false if not
 func isAnImage(d fs.DirEntry) bool {
 	if !d.IsDir() {
-		f, err := os.Open(d.Name())
+		f, err := os.Open(models.UploadDirectory + d.Name())
 		if err != nil {
 			return false
 		}

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -51,14 +52,13 @@ func isContentTypeAllowed(contentType string) bool {
 }
 
 // Return true if file is a real image and false if not
-func isAnImage(file string) bool {
-	i, err := os.Stat(file)
-	if os.IsNotExist(err) {
-		return false
-	}
+func isAnImage(f fs.DirEntry) bool {
+	if !f.IsDir() {
+		f, err := os.Open(f.Name())
+		if err != nil {
+			return false
+		}
 
-	if !i.IsDir() {
-		f, err := os.Open(file)
 		contentType, err := getFileContentType(f)
 		if err != nil {
 			return false
@@ -81,7 +81,6 @@ func errorHandler(msg string, c *MainController, err error, flash *beego.FlashDa
 	flash.Error(msg)
 	flash.Store(&c.Controller)
 	c.Redirect("/", 302)
-	return
 }
 
 // Upload source into a Google Storage bucket
@@ -97,7 +96,7 @@ func uploadGoogleStorage(source, destination string) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 	defer cancel()
 
-	client, err := storage.NewClient((ctx))
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to create a Google Cloud Storage NewClient(): " + err.Error())
 	}

--- a/controllers/get.go
+++ b/controllers/get.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	"html/template"
-	"io/ioutil"
+	"os"
 
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/logs"
@@ -25,12 +25,12 @@ func (c *MainController) Get() {
 	// Get all saved images and thumbnails
 	images := map[string]string{}
 	if models.StorageType == "local" {
-		files, err := ioutil.ReadDir(models.UploadDirectory)
+		files, err := os.ReadDir(models.UploadDirectory)
 		if err != nil {
 			logs.Critical("Error: " + err.Error())
 		}
 		for _, file := range files {
-			if isAnImage(models.UploadDirectory + file.Name()) {
+			if isAnImage(file) {
 				images[file.Name()] = generateThumbnailName(file.Name())
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lescactus/http-gallery-beego
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go v0.57.0 // indirect

--- a/models/storage.go
+++ b/models/storage.go
@@ -65,7 +65,7 @@ func bucketExists(b string) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 	defer cancel()
 
-	client, err := storage.NewClient((ctx))
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Minimal version required is now go v1.16
- Replace ioutil.ReadDir() with os.ReadDir()